### PR TITLE
Update admin.php

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -13080,6 +13080,8 @@ namespace Tqdev\PhpCrudAdmin\Column {
     {
         private $api;
         private $database;
+        private $properties;
+
 
         public function __construct(CrudApi $api)
         {


### PR DESCRIPTION
In PHP 8.2 and later, setting a value to an undeclared class property is deprecated .
#8 
@mevdschee 